### PR TITLE
Add support for WordPress Multisite installations.

### DIFF
--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -76,14 +76,14 @@
 	<p class="submit">
 
 		<?php if ( strcasecmp( 'connected', $this->get_redis_status() ) === 0 ) : ?>
-			<a href="<?php echo wp_nonce_url( admin_url( add_query_arg( 'action', 'flush-cache', $this->admin_page ) ), 'flush-cache' ); ?>" class="button button-primary button-large"><?php _e( 'Flush Cache', 'redis-cache' ); ?></a>
+			<a href="<?php echo wp_nonce_url( network_admin_url( add_query_arg( 'action', 'flush-cache', $this->admin_page ) ), 'flush-cache' ); ?>" class="button button-primary button-large"><?php _e( 'Flush Cache', 'redis-cache' ); ?></a>
 			&nbsp;
 		<?php endif; ?>
 
 		<?php if ( ! $this->object_cache_dropin_exists() ) : ?>
-			<a href="<?php echo wp_nonce_url( admin_url( add_query_arg( 'action', 'enable-cache', $this->admin_page ) ), 'enable-cache' ); ?>" class="button button-primary button-large"><?php _e( 'Enable Object Cache', 'redis-cache' ); ?></a>
+			<a href="<?php echo wp_nonce_url( network_admin_url( add_query_arg( 'action', 'enable-cache', $this->admin_page ) ), 'enable-cache' ); ?>" class="button button-primary button-large"><?php _e( 'Enable Object Cache', 'redis-cache' ); ?></a>
 		<?php elseif ( $this->validate_object_cache_dropin() ) : ?>
-			<a href="<?php echo wp_nonce_url( admin_url( add_query_arg( 'action', 'disable-cache', $this->admin_page ) ), 'disable-cache' ); ?>" class="button button-secondary button-large delete"><?php _e( 'Disable Object Cache', 'redis-cache' ); ?></a>
+			<a href="<?php echo wp_nonce_url( network_admin_url( add_query_arg( 'action', 'disable-cache', $this->admin_page ) ), 'disable-cache' ); ?>" class="button button-secondary button-large delete"><?php _e( 'Disable Object Cache', 'redis-cache' ); ?></a>
 		<?php endif; ?>
 
 	</p>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://till.kruss.me/donations/
 Tags: redis, predis, hhvm, pecl, caching, cache, object cache, wp object cache, server, performance, optimize, speed, load
 Requires at least: 3.3
 Tested up to: 4.2
-Stable tag: 1.1.1
+Stable tag: 1.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -82,6 +82,10 @@ Users with setups where multiple installs share a common `wp-config.php` or `$ta
 
 
 == Changelog ==
+
+= 1.2 =
+
+  * Added support for WordPress Multisite installations.
 
 = 1.1.1 =
 

--- a/redis-cache.php
+++ b/redis-cache.php
@@ -3,7 +3,7 @@
 Plugin Name: Redis Object Cache
 Plugin URI: http://wordpress.org/plugins/redis-cache/
 Description: A Redis backend for the WordPress Object Cache based on the Predis client library for PHP.
-Version: 1.1.1
+Version: 1.2
 Text Domain: redis-cache
 Domain Path: /languages
 Author: Till Krüss
@@ -27,11 +27,38 @@ class RedisObjectCache {
 
 		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_plugin_actions_links' ) );
 
+		// Create network admin menu if using multisite
+		if( is_multisite() ) {
+			$this->screen = 'settings_page_redis-cache';
+			$this->capability = 'manage_network_options';
+			$this->admin_page = 'settings.php?page=redis-cache';
+
+			add_action( 'network_admin_menu', array( $this, 'add_network_admin_menu_page' ) );
+		}
+
+		// Create Tools page if standard WP installation
+		if( ! is_multisite() ) {
+			add_action( 'admin_menu', array( $this, 'add_admin_menu_page' ) );
+		}
+
 		add_action( 'admin_notices', array( $this, 'show_admin_notices' ) );
-		add_action( 'admin_menu', array( $this, 'add_admin_menu_page' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
 		add_action( 'load-' . $this->screen, array( $this, 'do_admin_actions' ) );
 		add_action( 'load-' . $this->screen, array( $this, 'add_admin_page_notices' ) );
+
+	}
+
+	public function add_network_admin_menu_page() {
+
+		// add Network Admin settings page if using multisite
+		add_submenu_page(
+			'settings.php',
+			__( 'Redis Object Cache', 'redis-cache'),
+			__( 'Redis', 'redis-cache'),
+			$this->capability,
+			'redis-cache',
+			array( $this, 'show_admin_page' )
+		);
 
 	}
 
@@ -60,7 +87,7 @@ class RedisObjectCache {
 				// verify nonce
 				if ( $action === $name && wp_verify_nonce( $_GET[ '_wpnonce' ], $action ) ) {
 
-					$url = wp_nonce_url( admin_url( add_query_arg( 'action', $action, $this->admin_page ) ), $action );
+					$url = wp_nonce_url( network_admin_url( add_query_arg( 'action', $action, $this->admin_page ) ), $action );
 
 					if ( $this->initialize_filesystem( $url ) === false ) {
 						return; // request filesystem credentials
@@ -81,7 +108,7 @@ class RedisObjectCache {
 
 		// add settings link to plugin actions
 		return array_merge(
-			array( '<a href="' . admin_url( $this->admin_page ) . '">Settings</a>' ),
+			array( '<a href="' . network_admin_url( $this->admin_page ) . '">Settings</a>' ),
 			$links
 		);
 
@@ -166,7 +193,7 @@ class RedisObjectCache {
 
 		if ( $this->object_cache_dropin_exists() ) {
 
-			$url = wp_nonce_url( admin_url( add_query_arg( 'action', 'update-dropin', $this->admin_page ) ), 'update-dropin' );
+			$url = wp_nonce_url( network_admin_url( add_query_arg( 'action', 'update-dropin', $this->admin_page ) ), 'update-dropin' );
 
 			if ( $this->validate_object_cache_dropin() ) {
 
@@ -255,7 +282,7 @@ class RedisObjectCache {
 
 			if ( in_array( $action, $this->admin_actions ) ) {
 
-				$url = wp_nonce_url( admin_url( add_query_arg( 'action', $action, $this->admin_page ) ), $action );
+				$url = wp_nonce_url( network_admin_url( add_query_arg( 'action', $action, $this->admin_page ) ), $action );
 
 				if ( $action === 'flush-cache' ) {
 					$message = wp_cache_flush() ? 'cache-flushed' : 'flush-cache-failed';
@@ -287,7 +314,7 @@ class RedisObjectCache {
 
 				// redirect if status `$message` was set
 				if ( isset( $message ) ) {
-					wp_safe_redirect( admin_url( add_query_arg( 'message', $message, $this->admin_page ) ) );
+					wp_safe_redirect( network_admin_url( add_query_arg( 'message', $message, $this->admin_page ) ) );
 					exit;
 				}
 


### PR DESCRIPTION
The current version of the plugin appears in the Tools menu of every
site within a WordPress Multisite installation. In the case of a
Multisite installation, the administration options should only be
available to users with the Manage Network Options capability, and the
settings page should show within the Network section of the admin panel.

Note: I've also updated all calls to the admin_url function to network_admin_url. This is necessary for the plugin to work on WordPress Multisite installations, and simply reverts to the expected admin_url function if the installation is not multisite.