### PR TITLE
Fixed WP_CACHE_KEY_SALT

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -449,7 +449,7 @@ class WP_Object_Cache {
 		 * multi single WP installs on the same server.
 		 */
 		if ( ! defined( 'WP_CACHE_KEY_SALT' ) ) {
-			define( 'WP_CACHE_KEY_SALT', '' );
+			define( 'WP_CACHE_KEY_SALT', md5(DB_NAME . __FILE__) );
 		}
 
 		// Assign global and blog prefixes for use with keys


### PR DESCRIPTION
Uses md5(DB_NAME . __FILE__) to actually be unique, was just set to an empty string before..