### PR TITLE
provide local serialization functions.

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -528,9 +528,9 @@ class WP_Object_Cache {
 			$expiration = $this->validate_expiration( $expiration );
 
 			if ( $expiration ) {
-				$result = $this->parse_predis_response( $this->redis->setex( $derived_key, $expiration, maybe_serialize( $value ) ) );
+				$result = $this->parse_predis_response( $this->redis->setex( $derived_key, $expiration, $this->maybe_serialize( $value ) ) );
 			} else {
-				$result = $this->parse_predis_response( $this->redis->set( $derived_key, maybe_serialize( $value ) ) );
+				$result = $this->parse_predis_response( $this->redis->set( $derived_key, $this->maybe_serialize( $value ) ) );
 			}
 		}
 
@@ -616,7 +616,7 @@ class WP_Object_Cache {
 			return false;
 		} else {
 			$this->cache_hits++;
-			$value = maybe_unserialize( $result );
+			$value = $this->maybe_unserialize( $result );
 		}
 
 		$this->add_to_internal_cache( $derived_key, $value );
@@ -705,9 +705,9 @@ class WP_Object_Cache {
 		if ( ! in_array( $group, $this->no_redis_groups ) && $this->redis_status() ) {
 			$expiration = $this->validate_expiration($expiration);
 			if ( $expiration ) {
-				$result = $this->parse_predis_response( $this->redis->setex( $derived_key, $expiration, maybe_serialize( $value ) ) );
+				$result = $this->parse_predis_response( $this->redis->setex( $derived_key, $expiration, $this->maybe_serialize( $value ) ) );
 			} else {
-				$result = $this->parse_predis_response( $this->redis->set( $derived_key, maybe_serialize( $value ) ) );
+				$result = $this->parse_predis_response( $this->redis->set( $derived_key, $this->maybe_serialize( $value ) ) );
 			}
 		}
 
@@ -945,6 +945,105 @@ class WP_Object_Cache {
 			$expiration = intval( WP_REDIS_MAXTTL );
 		}
 		return $expiration;
+	}
+
+	/**
+	 * Serialization functions borrowed from WordPress. The official functions are not loaded until
+	 * after advanced-cache.php by which point the object cache should be fully available.
+	 * https://core.trac.wordpress.org/browser/trunk/src/wp-includes/functions.php
+	 */
+
+	/**
+	 * Unserialize value only if it was serialized.
+	 *
+	 * @param string $original Maybe unserialized original, if is needed.
+	 * @return mixed Unserialized data can be any type.
+	 */
+	protected function maybe_unserialize( $original ) {
+		if ( $this->is_serialized( $original ) ) // don't attempt to unserialize data that wasn't serialized going in
+			return @unserialize( $original );
+		return $original;
+	}
+
+	/**
+	 * Serialize data, if needed.
+	 * @param string|array|object $data Data that might be serialized.
+	 * @return mixed A scalar data
+	 */
+	protected function maybe_serialize( $data ) {
+		if ( is_array( $data ) || is_object( $data ) )
+			return serialize( $data );
+
+		if ( $this->is_serialized( $data, false ) )
+			return serialize( $data );
+
+		return $data;
+	}
+
+	/**
+	 * Check value to find if it was serialized.
+	 *
+	 * If $data is not an string, then returned value will always be false.
+	 * Serialized data is always a string.
+	 *
+	 * @param string $data   Value to check to see if was serialized.
+	 * @param bool   $strict Optional. Whether to be strict about the end of the string. Default true.
+	 * @return bool False if not serialized and true if it was.
+	 */
+	protected function is_serialized( $data, $strict = true ) {
+
+		// if it isn't a string, it isn't serialized.
+		if ( ! is_string( $data ) ) {
+			return false;
+		}
+		$data = trim( $data );
+	 	if ( 'N;' == $data ) {
+			return true;
+		}
+		if ( strlen( $data ) < 4 ) {
+			return false;
+		}
+		if ( ':' !== $data[1] ) {
+			return false;
+		}
+		if ( $strict ) {
+			$lastc = substr( $data, -1 );
+			if ( ';' !== $lastc && '}' !== $lastc ) {
+				return false;
+			}
+		} else {
+			$semicolon = strpos( $data, ';' );
+			$brace     = strpos( $data, '}' );
+			// Either ; or } must exist.
+			if ( false === $semicolon && false === $brace )
+				return false;
+			// But neither must be in the first X characters.
+			if ( false !== $semicolon && $semicolon < 3 )
+				return false;
+			if ( false !== $brace && $brace < 4 )
+				return false;
+		}
+		$token = $data[0];
+		switch ( $token ) {
+			case 's' :
+				if ( $strict ) {
+					if ( '"' !== substr( $data, -2, 1 ) ) {
+						return false;
+					}
+				} elseif ( false === strpos( $data, '"' ) ) {
+					return false;
+				}
+				// or else fall through
+			case 'a' :
+			case 'O' :
+				return (bool) preg_match( "/^{$token}:[0-9]+:/s", $data );
+			case 'b' :
+			case 'i' :
+			case 'd' :
+				$end = $strict ? '$' : '';
+				return (bool) preg_match( "/^{$token}:[0-9.E-]+;$end/", $data );
+		}
+		return false;
 	}
 
 }


### PR DESCRIPTION
`advanced-cache.php` should have full access to the object cache, but at that point in execution the `maybe_unserialize` function has not been loaded yet.

For example, see: https://github.com/WordPress/WordPress/blob/master/wp-settings.php#L63-L72

This will allow batcache users to use this Redis Object Cache as a backend. fixes #9 