### PR TITLE
Use WordPress constant to load Predis library

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -419,11 +419,11 @@ class WP_Object_Cache {
 				}
 
 				// check if bundled Predis library exists
-				if ( ! realpath( dirname( __FILE__ ) . '/plugins/redis-cache/includes/predis.php' ) ) {
+				if ( ! realpath( WP_CONTENT_DIR . '/plugins/redis-cache/includes/predis.php' ) ) {
 					throw new Exception;
 				}
 
-				require_once dirname( __FILE__ ) . '/plugins/redis-cache/includes/predis.php';
+				require_once WP_CONTENT_DIR . '/plugins/redis-cache/includes/predis.php';
 
 				Predis\Autoloader::register();
 


### PR DESCRIPTION
Modified object cache to use `WP_CONTENT_DIR` instead `dirname( __FILE__)`. This fixes an issue where the object cache couldn't find the Predis library. The cause was the fact that `object-cache.php` was symlinked into `wp-content`. `dirname( __FILE__)` would resolve to the wrong location.