### PR TITLE
Fixing crash that occurs when connection fails

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -374,9 +374,7 @@ class WP_Object_Cache {
 					$redis[ 'port' ] = 0;
 				}
 
-				if ( ! $this->redis->connect( $redis[ 'host' ], $redis[ 'port' ] ) ) {
-					throw new Exception;
-				}
+				$this->redis->connect( $redis[ 'host' ], $redis[ 'port' ] );
 
 				if ( isset( $redis[ 'password' ] ) ) {
 					$this->redis->auth( $redis[ 'password' ] );
@@ -385,8 +383,6 @@ class WP_Object_Cache {
 				if ( isset( $redis[ 'database' ] ) ) {
 					$this->redis->select( $redis[ 'database' ] );
 				}
-
-				$this->redis_connected = true;
 
 			} elseif ( strcasecmp( 'pecl', $redis_client ) === 0 ) {
 
@@ -406,8 +402,6 @@ class WP_Object_Cache {
 				if ( isset( $redis[ 'database' ] ) ) {
 					$this->redis->select( $redis[ 'database' ] );
 				}
-
-				$this->redis_connected = true;
 
 			} else {
 
@@ -430,10 +424,13 @@ class WP_Object_Cache {
 				$this->redis = new Predis\Client( $redis );
 				$this->redis->connect();
 
-				$this->redis_connected = true;
 				$this->redis_client .= ' v' . Predis\Client::VERSION;
 
 			}
+
+			/* Test the connection before setting connected flag */
+			$this->redis->ping();
+			$this->redis_connected = true;
 
 		} catch ( Exception $exception ) {
 


### PR DESCRIPTION
There are currently three possible Redis clients that handle connections in different
ways and this has lead to a disconnect with how connections are handled.  This pull
request adds a bit of consistency when connecting to the Redis server.

To reproduce this issue you'll need to set your `WP_REDIS_CLIENT` to pecl and then
run your application without starting your Redis server. (this is an easy way to
guarantee a failed connection)

Previously only the hhvm client would check the success of the connect call while the
other two clients just assumed a connection occurred.

Proposed solution is to remove the explicit checking from the hhvm client so it's
inline with the behavior of the other two clients.  After we've set up our connection
but before we leave the try block we'll attempt to ping the server which will fail if
a proper connection wasn't established giving us the desired behavior of not setting
`$this->redis_connected`.

Please let me know if I can provide more information or you'd like me to change my approach. 