### PR TITLE
Check core functions exist

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1,4 +1,4 @@
-®<?php
+<?php
 /*
 Plugin Name: Redis Object Cache
 Plugin URI: http://wordpress.org/plugins/redis-cache/

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1,4 +1,4 @@
-<?php
+®<?php
 /*
 Plugin Name: Redis Object Cache
 Plugin URI: http://wordpress.org/plugins/redis-cache/
@@ -625,9 +625,15 @@ class WP_Object_Cache {
 
 		$value = is_object( $value ) ? clone $value : $value;
 
-		do_action( 'redis_object_cache_get', $key, $value, $group, $force, $found );
+		if ( function_exists( 'do_action' ) ) {
+			do_action( 'redis_object_cache_get', $key, $value, $group, $force, $found );
+		}
 
-		return apply_filters( 'redis_object_cache_get', $value, $key, $group, $force, $found );
+		if ( function_exists( 'apply_filters' ) ) {
+			return apply_filters( 'redis_object_cache_get', $value, $key, $group, $force, $found );
+		} else {
+			return $value;
+		}
 	}
 
 	/**
@@ -722,7 +728,9 @@ class WP_Object_Cache {
 			$this->add_to_internal_cache( $derived_key, $value );
 		}
 
-		do_action( 'redis_object_cache_set', $key, $value, $group, $expiration );
+		if ( function_exists( 'do_action' ) ) {
+			do_action( 'redis_object_cache_set', $key, $value, $group, $expiration );
+		}
 
 		return $result;
 	}


### PR DESCRIPTION
The object cache can be used inside of an `advanced-cache.php` dropin, but that also means that the object cache can be loaded early enough that most of Core hasn't been included yet, notably the actions and filters callbacks.

Checking that Core functions exist first avoids fatal errors with plugins like Batcache, or any other `advanced-cache.php` dropin that leverages the object cache.