### PR TITLE
Change WP_CONTENT_DIR.'/plugins' to WP_PLUGIN_DIR

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -397,7 +397,7 @@ class WP_Object_Cache {
 
 				// Load bundled Predis library
 				if ( ! class_exists( 'Predis\Client' ) ) {
-					require_once WP_CONTENT_DIR . '/plugins/redis-cache/includes/predis.php';
+					require_once WP_PLUGIN_DIR . '/redis-cache/includes/predis.php';
 					Predis\Autoloader::register();
 				}
 


### PR DESCRIPTION
Fixes #36 

This is still not 100% accurate because one could still rename the directory of the plugin itself, but it fixes the problem when the plugin dir has been moved outside of `wp-content`.